### PR TITLE
Add list endpoint for all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ https://docs.sonata-project.org/projects/SonataUserBundle/en/4.x/reference/insta
 High-priority TODO items (convert to GitHub issues before doing further work):
 
 * Add more test logic to existing (mostly empty) ReadUserTest class.
-* Add an endpoint on the API user controller that allows an admin to list all users, regardless of group.
 * Add an endpoint to the API group controller that allows an admin to list all users in a group.
 * Update test logic to cover edge cases.
 * Fix/add integration tests for RUD operations on API user endpoints. 
@@ -119,7 +118,8 @@ High-priority TODO items (convert to GitHub issues before doing further work):
 * Refactor to abstract some more controller logic into services. The controllers are a bit fat now, and there's some duplicated code.
 * Create a custom UserManager class to replace the deprecated FOSUserBundle version, and move some logic from the UserService to that manager.
 * Make endpoint urls adhere to the "APIs You Don't Hate" standard. (This will be fairly simple.)
-
+* Add versioning to the user API -- either via a route prefix or via a header.
+* Add pagination to the endpoints that list users.
 
 Low-priority TODO items (convert to GitHub issues before doing further work):
 

--- a/code/src/Controller/ApiUserController.php
+++ b/code/src/Controller/ApiUserController.php
@@ -125,6 +125,46 @@ class ApiUserController
     }
 
     /**
+     * @route("/api/users", methods={"GET"}, name="api_user_list_all_users")
+     * @param Request $request
+     * @param TokenStorageInterface $tokenStorage
+     * @return JsonResponse
+     */
+    public function listAllUsers(
+        Request $request,
+        TokenStorageInterface $tokenStorage
+    ) : JsonResponse
+    {
+        if (
+        !$this->userService->checkApiUserIsAdmin($tokenStorage->getToken())
+        ) {
+            return $this->getUnauthorizedResponse();
+        }
+        try {
+            $serializer = new Serializer($this->normalizers, $this->encoders);
+            $users = $this->userManager->findUsers();
+            return new JsonResponse($serializer->serialize(
+                $users,
+                'json',
+                [
+                    'json_encode_options' => JSON_UNESCAPED_SLASHES,
+                    AbstractNormalizer::IGNORED_ATTRIBUTES =>
+                        SonataUserUser::attributesToIgnore
+                ]
+            ),
+                201,
+                [],
+                true
+            );
+        } catch (\Exception $e) {
+            return new JsonResponse(
+                ['message' => $e->getMessage()],
+                500
+            );
+        }
+    }
+
+    /**
      * @param Request $request
      * @param Serializer $serializer
      * @return mixed

--- a/code/tests/Acceptance/CreateUserTest.php
+++ b/code/tests/Acceptance/CreateUserTest.php
@@ -201,6 +201,9 @@ class CreateUserTest extends WebTestCase
     }
 
     /**
+     * TODO: Move this method to an abstract parent class.
+     *       (It's currently redefined in both this and ReadUserTest.)
+     *
      * @return object
      * @throws GuzzleException
      */
@@ -228,5 +231,4 @@ class CreateUserTest extends WebTestCase
 
         return $firstResponseObj;
     }
-
 }

--- a/code/tests/Acceptance/ReadUserTest.php
+++ b/code/tests/Acceptance/ReadUserTest.php
@@ -2,14 +2,131 @@
 
 namespace App\Tests\Acceptance;
 
+use GuzzleHttp\Exception\GuzzleException;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Dotenv\Dotenv;
 
 class ReadUserTest extends WebTestCase
 {
-    function testGetAllUsers(): void
+    const LOGIN_RELATIVE_URL = '/api/login_check';
+    const LIST_USERS_RELATIVE_URL = '/api/users';
+
+    public function testGetAllUsersWithAdminSucceeds(): void
     {
+        $firstResponseObj = $this->getSuperUserAuthenticationResponseObject();
+        $urlTwo = $_ENV['HOST_STRING'].self::LIST_USERS_RELATIVE_URL;
+        $client = new \GuzzleHttp\Client();
+        $secondResponse = $client->request('GET', $urlTwo, [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer ' . $firstResponseObj->token
+            ]
+        ]);
+
+        $secondResponseArray = json_decode(
+            $secondResponse->getBody()->getContents(),
+            true
+        );
+
+        self::assertEquals(201, $secondResponse->getStatusCode());
+        self::assertIsArray($secondResponseArray);
+        self::assertCount(3, $secondResponseArray);
+        self::assertEquals(
+            'bobuser',
+            $secondResponseArray[2]['username']
+        );
+        self::assertEquals(
+            'bobuser@example.com',
+            $secondResponseArray[2]['email']
+        );
+        self::assertEquals(
+            [0 => 'ROLE_USER'],
+            $secondResponseArray[2]['roles']
+        );
+        self::assertEquals(
+            true,
+            $secondResponseArray[2]['accountNonExpired']
+        );
+        self::assertEquals(
+            true,
+            $secondResponseArray[2]['accountNonLocked']
+        );
+        self::assertEquals(
+            true,
+            $secondResponseArray[2]['credentialsNonExpired']
+        );
+        //dd($secondResponseArray);
+
+    }
+
+    function testGetAllUsersWithNonAdminFails(): void
+    {
+        $dotEnv = new Dotenv();
+        $dotEnv->overload(__DIR__ . '/../../.env');
+        if (file_exists(__DIR__ . '/../../.env.local')) {
+            $dotEnv->overload(__DIR__ . '/../../.env.local');
+        }
+        $dotEnv->overload(__DIR__.'/../../.env.test');
+        $urlOne = $_ENV['HOST_STRING'] . self::LOGIN_RELATIVE_URL;
+        $client = new \GuzzleHttp\Client();
+        $firstResponse = $client->request('POST', $urlOne, [
+            'body' => '{"username":"normaluser","password":"password"}',
+            'headers' => ['Content-Type' => 'application/json']
+        ]);
+        $urlTwo = $_ENV['HOST_STRING'] . self::LIST_USERS_RELATIVE_URL;
+        $firstResponseObj = json_decode(
+            $firstResponse->getBody()->getContents()
+        );
+        try {
+            $secondResponse = $client->request(
+                'GET',
+                $urlTwo,
+                [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                        'Authorization' => 'Bearer '.$firstResponseObj->token,
+                    ],
+                ]
+            );
+            $statusCode = $secondResponse->getStatusCode();
+        } catch (GuzzleException $e) {
+            $statusCode = $e->getCode();
+        }
+        self::assertEquals(403, $statusCode);
         //TODO: Build the endpoint to show all users and the test.
 
         self::assertTrue(true);
+    }
+
+    /**
+     * TODO: Move this method to an abstract parent class.
+     *       (It's currently redefined in both this and CreateUserTest.)
+     *
+     * @return object
+     * @throws GuzzleException
+     */
+    private function getSuperUserAuthenticationResponseObject(): object
+    {
+        $dotEnv = new Dotenv();
+        $dotEnv->overload(__DIR__.'/../../.env');
+        if (file_exists(__DIR__.'/../../.env.local')) {
+            $dotEnv->overload(__DIR__.'/../../.env.local');
+        }
+        $dotEnv->overload(__DIR__.'/../../.env.test');
+        $urlOne = $_ENV['HOST_STRING'].self::LOGIN_RELATIVE_URL;
+        $client = new \GuzzleHttp\Client();
+        $firstResponse = $client->request(
+            'POST',
+            $urlOne,
+            [
+                'body' => '{"username":"superuser","password":"password"}',
+                'headers' => ['Content-Type' => 'application/json']
+            ]
+        );
+        $firstResponseObj = json_decode(
+            $firstResponse->getBody()->getContents()
+        );
+
+        return $firstResponseObj;
     }
 }


### PR DESCRIPTION
Adds logic (including tests, of course) for an endpoint that lists all users, regardless of group. Endpoint is only accessable by admins.